### PR TITLE
feature: support dual-publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Thumbs.db
 deno.lock
 *.lock
 _next
+npm
+,/npm/**/*

--- a/_build_npm.ts
+++ b/_build_npm.ts
@@ -1,9 +1,13 @@
-#!/usr/bin/env -S deno run -A
+#!/usr/bin/env -S deno run -A --unstable
 
-import { build, emptyDir } from "https://deno.land/x/dnt@0.32.1/mod.ts";
 import { VERSION } from "./version.ts";
+import { build, colors, emptyDir } from "./deps.ts";
 
-const NPM_DIR = "./_npm";
+const ansi = colors();
+const NPM_DIR = "./npm";
+
+const name = "serialize-typescript";
+const version = Deno.args[0] ?? VERSION;
 
 async function start() {
   await emptyDir(NPM_DIR);
@@ -11,29 +15,64 @@ async function start() {
   await build({
     entryPoints: ["./mod.ts"],
     outDir: NPM_DIR,
-    mappings: {
-      "./http_server_native.ts": "./http_server_node.ts",
-    },
-    shims: {
-      blob: true,
-      crypto: true,
-      deno: true,
-    },
-    test: true,
+    packageManager: "pnpm",
+    test: false,
     typeCheck: false,
+    scriptModule: false,
     compilerOptions: {
       importHelpers: true,
-      target: "ES2021",
+      target: "Latest",
       lib: ["esnext", "dom", "dom.iterable"],
+      skipLibCheck: true,
+      emitDecoratorMetadata: true,
+    },
+    shims: {
+      deno: true,
+      crypto: true,
+      weakRef: true,
+      timers: true,
+      custom: [
+        { // janky temporary shim for missing dependency types
+          module: "./mod.d.ts",
+          globalNames: ["Primitive", "Printable", "Keyable", "Class"],
+        },
+      ],
     },
     package: {
-      name: "serializd",
-      version: Deno.args[0] || VERSION,
-      author: "Nicholas Berlette <nick@berlette.com>",
+      name,
+      version,
+      author: {
+        name: "Nicholas Berlette",
+        email: "nick@berlette.com",
+        url: "https://github.com/nberlette",
+      },
       license: "MIT",
       private: false,
+      packageManager: "pnpm@7.18.2",
+      publishConfig: {
+        access: "public",
+        registry: "https://registry.npmjs.org",
+      },
+      repository: "deno911/serialize",
+      bugs: "https://github.com/deno911/serialize/issues",
+      readme: "https://github.com/deno911/serialize/#readme",
+      homepage: "https://deno.land/x/serialize?doc",
       description:
-        "Serialize JavaScript/TypeScript into a JSON superset, retaining Maps, Sets, Dates, RegExps, Functions, and more. Based on serialize-javascript, rewritten in TS for the modern era. Supports Deno and Node.",
+        "Serializes JavaScript/TypeScript code into a JSON superset with support for modern built-ins like Map, Set, Date, BigInt, and many more. Inspired by serialize-javascript and revived for the modern web. Available for Deno and Node.",
+      prettier: "@brlt/prettier",
+      eslintConfig: {
+        extends: ["@brlt"],
+      },
+      dependencies: {
+        "tslib": "~2.3.1",
+      },
+      devDependencies: {
+        "@types/node": "^17",
+        "@brlt/prettier": "latest",
+        "@brlt/eslint-config": "latest",
+        "eslint": "^8.30.0",
+        "prettier": "^2.8.1",
+      },
       keywords: [
         "serialize",
         "typescript",
@@ -46,26 +85,55 @@ async function start() {
       engines: {
         node: ">=16.5.0",
       },
-      homepage: "https://deno.land/x/serialize?doc",
-      readme: "https://github.com/deno911/serialize/#readme",
-      repository: {
-        type: "git",
-        url: "git+https://github.com/deno911/serialize.git",
-      },
-      bugs: {
-        url: "https://github.com/deno911/serialize/issues",
-      },
-      dependencies: {
-        "tslib": "~2.3.1",
-      },
-      devDependencies: {
-        "@types/node": "^17",
-      },
     },
   });
 
-  await Deno.copyFile("LICENSE", `${NPM_DIR}/LICENSE`);
-  await Deno.copyFile("README.md", `${NPM_DIR}/README.md`);
+  for (const file of ["LICENSE", "README.md"]) {
+    await Deno.copyFile(file, `${NPM_DIR}/${file}`);
+  }
 }
 
-start();
+start().then(async () => {
+  // const NPM_TOKEN = Deno.env.get("NPM_TOKEN") ?? Deno.env.get("NODEAUTHTOKEN") ?? Deno.env.get("NODE_TOKEN") ?? undefined;
+
+  const postbuild_install = Deno.run({
+    cwd: "./npm",
+    cmd: ["deno", "run", "-A", "npm:pnpm@latest", "install"],
+  });
+
+  const postbuild_format = Deno.run({
+    cwd: "./npm",
+    cmd: ["deno", "run", "-A", "npm:prettier@latest", "--write", "."],
+  });
+
+  const postbuild = [
+    postbuild_install,
+    postbuild_format,
+  ];
+
+  // if (NPM_TOKEN) {
+  //   const postbuild_publish = Deno.run({
+  //     cwd: "./npm",
+  //     env: {
+  //       NPM_TOKEN,
+  //     },
+  //     cmd: ["deno", "run", "-A", "npm:pnpm@latest", "publish"],
+  //   });
+
+  //   postbuild.push(postbuild_publish);
+  // }
+
+  const _results = await Promise.all(postbuild.map((step) => step.status()));
+
+  if (_results.every((res) => res.success)) {
+    console.log(
+      ansi.gray(
+        ` ${ansi.bold.green("✓")} successfully built ${
+          ansi.bold.underline.cyan(`${name}@${version}`)
+        }. Ready to publish to ${ansi.brightRed.bold.underline("npm")} ${
+          ansi.dim.brightRed("(registry.npmjs.org)")
+        }`,
+      ),
+    );
+  }
+});

--- a/_util.ts
+++ b/_util.ts
@@ -1,4 +1,4 @@
-import { assert, is } from "https://x.nest.land/dis@0.3.0-rc.3/mod.ts";
+import { is } from "./deps.ts";
 
 // Generate an internal UID to make the regexp pattern harder to guess.
 export const UID_LENGTH = 16;
@@ -84,10 +84,10 @@ export function escapeUnsafeChars<C extends string>(char: C) {
 export function getIndentSize(space: string | number = 0): number {
   let indent = 0;
   const tabSize = 8;
-  if (is.number(space) || is.numericString(space)) {
-    indent = +space;
-  } else if (is.nonEmptyString(space)) {
+  if (is.nonEmptyString(space)) {
     indent = space.replace(/\t/g, " ".repeat(tabSize)).split("").length;
+  } else if (is.number(space) || is.numericString(space)) {
+    indent = +space;
   } else {
     indent = 0;
   }
@@ -142,5 +142,3 @@ export function validateRegExpFlags<S extends string>(flags: S) {
   const f = String(flags).toLowerCase().trim().replace(/[^dgimsuy]/g, "");
   return (f.length > 0 ? f : "") as ValidateRegExpFlag<S>;
 }
-
-export { assert, is };

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,12 +1,10 @@
 {
-  "lock": false,
   "tasks": {
     "test": "deno test -A --unstable --no-check",
     "prepublish": "deno fmt; deno lint --unstable; deno task test",
-    "publish": "deno task prepublish; deno task publish:nest; deno task publish:deno; deno task build:npm && deno task publish:npm",
-    "publish:nest": "deno install -A --unstable https://deno.land/x/eggs/cli.ts; [ -n \"$NESTAPIKEY\" ] && eggs link ${NESTAPIKEY-} && eggs publish",
+    "publish": "deno task prepublish; deno task publish:deno; deno task build:npm && deno task publish:npm",
     "publish:deno": "deno run -A https://deno.land/x/publish/cli.ts",
-    "publish:npm": "deno run -A --unstable npm:pnpm@latest publish",
+    "publish:npm": "deno run -A --unstable npm:pnpm@latest publish --report-summary --no-git-checks --ignore-scripts --force --access=public -C ./npm",
     "build:npm": "deno run -A ./_build_npm.ts"
   },
   "compilerOptions": {
@@ -17,6 +15,9 @@
       "dom.extras",
       "dom.iterable",
       "deno.ns"
+    ],
+    "types": [
+      "./mod.d.ts"
     ]
   },
   "lint": {
@@ -29,12 +30,18 @@
         "ban-ts-comment"
       ]
     },
+    "files": {
+      "exclude": [
+        "./npm/**/*"
+      ]
+    },
     "report": "compact"
   },
   "fmt": {
     "files": {
       "exclude": [
-        "./.*"
+        "./.*",
+        "./npm/**/*"
       ]
     },
     "options": {

--- a/deps.ts
+++ b/deps.ts
@@ -1,15 +1,10 @@
-export {
-  type Assert,
-  assert,
-  is,
-  type TypeName,
-} from "https://x.nest.land/dis@0.3.0-rc.3/mod.ts";
+export { assert, is } from "https://deno.land/x/dis@0.2.0/mod.ts";
 
 export { $ } from "https://deno.land/x/dax@0.17.0/mod.ts";
 
 export { colors } from "https://deno.land/x/cliffy@v0.25.6/ansi/mod.ts";
 
-export * from "https://deno.land/std@0.170.0/fs/mod.ts";
+export { type ExpandGlobOptions } from "https://deno.land/std@0.170.0/fs/mod.ts";
 
 export * as semver from "https://deno.land/std@0.170.0/semver/mod.ts";
 
@@ -18,3 +13,5 @@ export * as JSONC from "https://deno.land/std@0.170.0/encoding/jsonc.ts";
 export * as YAML from "https://deno.land/std@0.170.0/encoding/yaml.ts";
 
 export * as TOML from "https://deno.land/std@0.170.0/encoding/toml.ts";
+
+export { build, emptyDir } from "https://deno.land/x/dnt@0.32.1/mod.ts";

--- a/deserialize.ts
+++ b/deserialize.ts
@@ -1,5 +1,5 @@
-import serialize from "./serialize.ts";
-import { is } from "./_util.ts";
+import { serialize } from "./serialize.ts";
+import { is } from "./deps.ts";
 
 /**
  * Deserialize in a super unsafe way. This should probably never be used, as it

--- a/egg.json
+++ b/egg.json
@@ -8,10 +8,10 @@
   "version": "1.0.0",
   "releaseType": false,
   "bump": false,
-  "unstable": true,
+  "unstable": false,
   "unlisted": false,
   "files": [
-    "./{serialize,deserialize,mod,_util}.ts",
+    "./{serialize,deserialize,mod,_util,deps}.ts",
     "./{LICENSE,README.md}",
     "./deno.json*"
   ],

--- a/mod.d.ts
+++ b/mod.d.ts
@@ -1,0 +1,135 @@
+export type Primitive =
+  | string
+  | number
+  | bigint
+  | boolean
+  | symbol
+  | undefined
+  | object
+  | Function;
+
+export interface WeakRef<T extends object> {
+  readonly [Symbol.toStringTag]: "WeakRef";
+
+  /**
+   * Returns the WeakRef instance's target object, or undefined if the target object has been
+   * reclaimed.
+   */
+  deref(): T | undefined;
+}
+
+export interface WeakRefConstructor {
+  readonly prototype: WeakRef<any>;
+
+  /**
+   * Creates a WeakRef instance for the given target object.
+   * @param target The target object for the WeakRef instance.
+   */
+  new <T extends object>(target: T): WeakRef<T>;
+}
+
+export const WeakRef: WeakRefConstructor;
+
+// deno-fmt-ignore
+export type Flatten<T, Deep = false, Infer = false> =
+  | T extends Keyable
+    ? Infer extends true
+      ? T extends infer U
+        ? Flatten<U, Deep, false>
+      : never
+    : { [K in keyof T]: Deep extends true ? Flatten<T[K], true, Infer> : T[K] }
+  : T;
+
+export type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends (
+    k: infer I,
+  ) => void ? I
+    : never;
+
+export type UnionToFunction<T> = T extends any ? () => T : never;
+
+export type LastOf<T> = UnionToIntersection<UnionToFunction<T>> extends
+  () => infer R ? R
+  : never;
+
+export type Push<T extends unknown[], V> = [
+  ...T,
+  ...(V extends unknown[] ? V : [V]),
+];
+
+export type UnionToTuple<
+  T,
+  L = LastOf<T>,
+  N = [T] extends [never] ? true : false,
+> = true extends N ? [] : Push<UnionToTuple<Exclude<T, L>>, L>;
+
+/**
+ * Matches a `class` constructor.
+ * @see https://mdn.io/Classes.
+ */
+export interface Class<
+  Proto = unknown,
+  Args extends any[] = any[],
+> extends Constructor<Proto, Args> {
+  readonly prototype: Proto;
+}
+
+export interface Constructor<Proto = unknown, Args extends any[] = any[]> {
+  new (...args: Args): Proto;
+}
+
+export type Predicate<T = unknown> = (value: unknown) => value is T;
+
+/**
+ * Matches any primitive value.
+ * @see https://mdn.io/Primitive
+ */
+export type Primitive =
+  | null
+  | undefined
+  | string
+  | number
+  | boolean
+  | symbol
+  | bigint;
+
+/**
+ * @see {@link Printable} for more information on Printable Primitive types.
+ */
+export type MaybePrintable = Exclude<Primitive, symbol>;
+
+/**
+ * The "Printable" Primitives - `string`, `number`, `boolean`, `bigint` - are
+ * the subset of the Primitive types that can be printed in Template Literal
+ * types (a feature of TypeScript 4.1+).
+ *
+ * _Technically_ `null` and `undefined` are also printable, but only as the
+ * literal strings `"null"` and `"undefined"`, respectively. As such, they
+ * are not included in this type.
+ *
+ * @see {@linkcode MaybePrintable} if you need to include `null` and `undefined` in the Printable type for your use case.
+ */
+export type Printable = NonNullable<MaybePrintable>;
+
+/**
+ * Matches any [typed array](https://mdn.io/TypedArray).
+ * @see https://mdn.io/TypedArray
+ */
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
+
+export type Keyable =
+  | Record<PropertyKey, unknown>
+  | unknown[]
+  | Map<any, any>
+  | Set<any>;


### PR DESCRIPTION
# 🎄 Merry Christmas! 🎅🏽

- [x] feat: add npm build step with dnt
- [x] chore: update egg.json
- [x] feat: 🎄 improve function serialization
  - behavior is now more consistent + uniform when serializing:
    - object methods
    - arrow functions
    - enhanced object literal methods
    - regular (pure) functions 
- [x] some additional improvements with serialization:
  - added support for compact/non-pretty printing
  - when `options.space` is `0`, serialized functions are now stripped 
    of leading and trailing whitespace, as well as line-breaks. this should
    improve their flow with the rest of the output, and reduce file size.
  - when `options.space` is `> 0`, the inner function bodies are now 
    indented an extra step and their alignment is corrected in respect to
    the opening/closing brackets which surround them. 
  - the above bullet point also applies for all `Set` and `Map` objects.

